### PR TITLE
Modernize image: HEALTHCHECK, BuildKit cache, README, Trivy gating

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,8 +68,19 @@ jobs:
           docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:test caddy version
           docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:test caddy build-info
           docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:test caddy list-modules
-      - 
-        name: Run Trivy vulnerability scanner
+      -
+        name: Trivy gate (fail on fixable CRITICAL)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: image
+          image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:test
+          severity: 'CRITICAL'
+          ignore-unfixed: true
+          exit-code: '1'
+          hide-progress: false
+      -
+        name: Trivy report (SARIF for Security tab)
+        if: always()
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: image
@@ -79,8 +90,9 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'MEDIUM,CRITICAL,HIGH'
           hide-progress: false
-      - 
+      -
         name: Upload Trivy scan results to GitHub Security tab
+        if: always()
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
+# syntax=docker/dockerfile:1
 FROM caddy:builder-alpine AS builder
 
-RUN xcaddy build  --with github.com/caddy-dns/cloudflare \
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    xcaddy build \
+      --with github.com/caddy-dns/cloudflare \
       --with github.com/lucaslorentz/caddy-docker-proxy/v2
 
 FROM caddy:alpine
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+# Probes Caddy's admin API (default 127.0.0.1:2019). Override or disable
+# (`--no-healthcheck`) if you set `admin off` in your Caddyfile.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --quiet --tries=1 --spider http://127.0.0.1:2019/config/ || exit 1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 
 # caddy-docker-cloudflaredns
-Caddy webserver v2 in a docker with cloudflaredns plugin enabled. 
-The docker containers are built for amd64 & arm64 / aarch64. 
-Its available both at docker under *kingpin/caddy-docker-cloudflaredns:latest* & *ghcr.io/kingpin/caddy-docker-cloudflaredns:latest*
+Caddy webserver v2 in a docker with the following plugins built in:
+
+- [`caddy-dns/cloudflare`](https://github.com/caddy-dns/cloudflare) — Cloudflare DNS provider for ACME DNS-01 challenges.
+- [`lucaslorentz/caddy-docker-proxy`](https://github.com/lucaslorentz/caddy-docker-proxy) — generates the Caddyfile from labels on other Docker containers, so Caddy auto-configures itself as you start/stop services.
+
+The docker containers are built for amd64, arm64 / aarch64, and arm/v7.
+Available at:
+
+- `kingpin/caddy-docker-cloudflaredns:latest` (Docker Hub)
+- `ghcr.io/kingpin/caddy-docker-cloudflaredns:latest` (GHCR)
+- `quay.io/kingpinx1/caddy-docker-cloudflaredns:latest` (Quay)
+
+The image ships a `HEALTHCHECK` that probes Caddy's admin API on `127.0.0.1:2019`. If you set `admin off` in your Caddyfile, run with `--no-healthcheck` or override `HEALTHCHECK` in your own image.
 
 **docker run** : 
 


### PR DESCRIPTION
## Summary

Four targeted modernization changes to the Caddy image — no plugin set changes, no consumer-visible breakage, no tag-strategy churn.

- **`Dockerfile`**: enable BuildKit syntax + cache mounts for `/root/.cache/go-build` and `/go/pkg/mod`, so rebuilds reuse the Go module/compiler cache (faster CI on cache hits).
- **`Dockerfile`**: add `HEALTHCHECK` probing Caddy's admin API at `127.0.0.1:2019/config/`. Override with `--no-healthcheck` if the Caddyfile uses `admin off`.
- **`README.md`**: document the `lucaslorentz/caddy-docker-proxy` plugin (previously unmentioned despite being built in), correct the platform list (`arm/v7` was missing), and add the Quay registry (was missing).
- **`.github/workflows/docker-publish.yml`**: split the single Trivy step into a **gate** (`severity=CRITICAL`, `ignore-unfixed`, `exit-code=1` — fails the build) and a **report** step (MEDIUM/HIGH/CRITICAL → SARIF, `if: always()` so reports still publish when the gate fails). Builds now fail on fixable CRITICAL CVEs instead of silently uploading and continuing.

## Test plan

- [x] `docker buildx build --load .` succeeds (Caddy v2.11.3, build 32.6s with no warm cache)
- [x] `caddy version` reports v2.11.3
- [x] `caddy list-modules` shows both `dns.providers.cloudflare` and `docker_proxy`
- [x] Container with default config transitions `starting → healthy` within ~30s
- [ ] CI workflow runs end-to-end against the branch (verify Trivy gate path on a clean image)
- [ ] Verify BuildKit cache reuse on a second CI run (look for faster `xcaddy build` step)

## Out of scope (deferred)

Discussed during scoping but intentionally skipped to keep this PR focused:

- Pinning base images to specific Caddy versions (`caddy:2.10-builder-alpine`).
- Semver tag strategy (`:v1` frozen anchor, port of the manual retag workflow from `caddy-docker-xtra`) — can revisit if/when a breaking change lands.
- Supply-chain hardening (xcaddy plugin pinning, SBOM/provenance attestations, OCI labels, hadolint).